### PR TITLE
Fix model selection dropdown scroll issue

### DIFF
--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -176,6 +176,8 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
           style={{
             backgroundColor: theme === 'light' ? 'white' : '#1e1e29',
             borderColor: theme === 'light' ? '#e5e7eb' : '#374151',
+            maxHeight: '300px', // P6425
+            overflowY: 'auto', // Pec44
           }}
           role="listbox"
           aria-labelledby="model-selector"

--- a/src/components/SettingsDropdown.tsx
+++ b/src/components/SettingsDropdown.tsx
@@ -104,6 +104,8 @@ const SettingsDropdown: React.FC<SettingsDropdownProps> = ({
             boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
             right: 0,
             top: '100%',
+            maxHeight: '400px', // P45d2
+            overflowY: 'auto', // P6046
           }}
         >
           <div className="p-6">


### PR DESCRIPTION
Add scrollability to the model selection dropdown inside the cog dropdown.

* Add `maxHeight` and `overflowY` properties to the dropdown container in `src/components/SettingsDropdown.tsx` to limit its height and enable scrolling.
* Add `maxHeight` and `overflowY` properties to the dropdown container in `src/components/ModelSelector.tsx` to limit its height and enable scrolling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/a14a-org/next-lm-chat/pull/1?shareId=9dbae1f0-d4c4-426b-b333-b2dbe0643662).