### PR TITLE
chore: CI test foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  merge_group:
 
 # contents: write is required only for the Dependabot lockfile-regen commit below.
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,34 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main, develop]
   push:
     branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
 
+# contents: write is required only for the Dependabot lockfile-regen commit below.
 permissions:
   contents: write
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
+      # Dependabot only updates package.json, not bun.lock. Regenerate the
+      # lockfile on Dependabot PRs so `--frozen-lockfile` does not drift.
       - name: Install dependencies (regen lockfile for Dependabot)
         run: |
           if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
@@ -31,6 +36,7 @@ jobs:
           else
             bun install --frozen-lockfile
           fi
+
       - name: Commit regenerated lockfile (Dependabot only)
         if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
         run: |
@@ -46,9 +52,9 @@ jobs:
         run: bun run lint
 
       - name: Type check
-        run: bunx --bun tsc --noEmit
+        run: bun run typecheck
 
-      - name: Build application
+      - name: Build
         run: bun run build
 
       - name: Verify build artifacts
@@ -58,3 +64,17 @@ jobs:
             exit 1
           fi
           echo "Build successful"
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Smoke tests
+        run: bun run test:smoke
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
+        "@playwright/test": "^1.49.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^25",
         "@types/react": "^19",
@@ -125,6 +126,8 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -243,6 +246,8 @@
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -413,6 +418,10 @@
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
 		"start": "next start",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write --unsafe .",
-		"format": "biome format --write ."
+		"format": "biome format --write .",
+		"typecheck": "tsc --noEmit",
+		"test:smoke": "playwright test smoke.spec.ts --project=chromium"
 	},
 	"dependencies": {
 		"axios": "^1.8.2",
@@ -25,6 +27,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.13",
+		"@playwright/test": "^1.49.0",
 		"@tailwindcss/postcss": "^4",
 		"@types/node": "^25",
 		"@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export const config = defineConfig({
+	testDir: "./tests",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: "html",
+
+	use: {
+		baseURL: "http://localhost:3000",
+		trace: "on-first-retry",
+	},
+
+	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+	webServer: {
+		command: "bun run dev",
+		url: "http://localhost:3000",
+		reuseExistingServer: !process.env.CI,
+		timeout: 120000,
+	},
+});
+
+export default config;

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+// Smoke tests: every key route must render server-side without an HTTP error
+// and without throwing an uncaught client exception. Intentionally content-
+// agnostic so dependency bumps don't break it on copy changes — it verifies
+// the app still boots and routes still resolve.
+const routes = ["/"];
+
+for (const path of routes) {
+	test(`smoke: ${path} renders without errors`, async ({ page }) => {
+		const pageErrors: string[] = [];
+		page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+		const response = await page.goto(path, { waitUntil: "domcontentloaded" });
+
+		expect(response, `no response for ${path}`).not.toBeNull();
+		expect(response?.status(), `HTTP status for ${path}`).toBeLessThan(400);
+		await expect(page.locator("body")).toBeVisible();
+		expect(pageErrors, `uncaught exceptions on ${path}`).toEqual([]);
+	});
+}


### PR DESCRIPTION
## Summary

Applies the standard CI / test foundation to next-lm-chat as part of the portfolio-wide CI/test rollout (reference: a14a-org/ccj-web, a14a-org/sigil-logomaker).

### Changes
- **`.github/workflows/ci.yml`** — augmented the existing workflow:
  - Bumped `actions/checkout@v4` → `@v6`.
  - Added a `concurrency` group (`ci-${{ github.ref }}`, cancel-in-progress).
  - Switched typecheck to the `bun run typecheck` script (was inline `bunx --bun tsc --noEmit`).
  - Added Playwright chromium install, `bun run test:smoke`, and a `playwright-report` artifact upload (`if: always()`).
  - Preserved the existing Bun lockfile-regen + commit steps for Dependabot, the `contents: write` permission, and the `main` + `develop` push/PR triggers.
- **`playwright.config.ts`** — new; chromium-only project, `baseURL` + `webServer` (`bun run dev`) on port 3000 (matches the repo's dev script).
- **`tests/smoke.spec.ts`** — new; content-agnostic smoke test. The app exposes a single page route (`/`); each route asserts HTTP status < 400, body visible, and no uncaught pageerror.
- **`package.json`** — added `typecheck` and `test:smoke` scripts, plus `@playwright/test` devDependency (the repo had no test runner).
- **`bun.lock`** — regenerated; only adds `@playwright/test`/`playwright`/`playwright-core` (+ transitive `fsevents`).
- **`.gitignore`** — ignore Playwright `test-results/` and `playwright-report/`.

### Not changed
- **`.github/dependabot.yml`** already meets the standard (npm + github-actions, weekly Monday, grouped minor/patch, PR limit 10), so it was left as-is.
- Runner was already `ubuntu-latest` — no self-hosted switch needed.

### Local validation (all green)
- `bun run lint` (biome) — pass (pre-existing warnings only)
- `bun run typecheck` (tsc --noEmit) — pass
- `bun run build` (next build) — pass, `.next` produced
- `bun run test:smoke` (chromium) — 1/1 passed