### PR TITLE
feat: add ChiliTrack alongside Umami

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+      - name: Unit tests
+        run: bun run test:unit
+
       - name: Build
         run: bun run build
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Create a `.env.local` file in the root directory:
 | `LM_STUDIO_API_URL` | Base URL for the LLM API | No | `https://example.com/v1` |
 | `NEXT_PUBLIC_APP_NAME` | Application name displayed in UI | No | `Next LM Chat` |
 | `NEXT_PUBLIC_DEFAULT_MODEL` | Default model to use | No | `local-model` |
+| `NEXT_PUBLIC_CHILITRACK_SCRIPT_URL` | ChiliTrack collector script URL | No | `https://ingest.chilitrack.com/script.js` |
+| `NEXT_PUBLIC_CHILITRACK_WEBSITE_ID` | Public ChiliTrack website ID | No | Production `chat.a14a.org` site |
 
 ### Running the App
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@biomejs/biome": "^2.5.2",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.2",
+        "@types/bun": "1.3.14",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -329,6 +330,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "postcss": "^8.5.15", "tailwindcss": "4.3.2" } }, "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -416,6 +419,8 @@
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"lint:fix": "biome check --write --unsafe .",
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",
+		"test:unit": "bun test src/**/*.test.ts",
 		"test:smoke": "playwright test smoke.spec.ts --project=chromium"
 	},
 	"dependencies": {
@@ -30,6 +31,7 @@
 		"@biomejs/biome": "^2.5.2",
 		"@playwright/test": "^1.61.1",
 		"@tailwindcss/postcss": "^4.3.2",
+		"@types/bun": "1.3.14",
 		"@types/node": "^26.1.1",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Script from "next/script";
+import AnalyticsScripts from "../components/AnalyticsScripts";
 import ParticleBackground from "../components/ParticleBackground";
 import { ThemeProvider } from "../context/ThemeContext";
 
@@ -40,11 +40,7 @@ export default function RootLayout({
 						{children}
 					</div>
 				</ThemeProvider>
-				<Script
-					src="https://analytics.a14a.org/script.js"
-					data-website-id="3ffe85b0-bad7-4843-a33e-a13ee2caa8ac"
-					strategy="lazyOnload"
-				/>
+				<AnalyticsScripts />
 			</body>
 		</html>
 	);

--- a/src/components/AnalyticsScripts.tsx
+++ b/src/components/AnalyticsScripts.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Script from "next/script";
+import { settleAnalyticsProvider } from "../utils/analytics";
+
+export default function AnalyticsScripts() {
+	return (
+		<>
+			<Script
+				src="https://analytics.a14a.org/script.js"
+				data-website-id="3ffe85b0-bad7-4843-a33e-a13ee2caa8ac"
+				strategy="lazyOnload"
+				onReady={() => settleAnalyticsProvider("umami", "ready")}
+				onError={() => settleAnalyticsProvider("umami", "failed")}
+			/>
+			<Script
+				src={
+					process.env.NEXT_PUBLIC_CHILITRACK_SCRIPT_URL ||
+					"https://ingest.chilitrack.com/script.js"
+				}
+				data-website-id={
+					process.env.NEXT_PUBLIC_CHILITRACK_WEBSITE_ID ||
+					"63d4f14a-c808-4ce9-885b-5ff9f27cb0b1"
+				}
+				data-chili-mode="side-by-side"
+				data-domains="chat.a14a.org"
+				strategy="lazyOnload"
+				onReady={() => settleAnalyticsProvider("chili", "ready")}
+				onError={() => settleAnalyticsProvider("chili", "failed")}
+			/>
+		</>
+	);
+}

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,0 +1,42 @@
+/// <reference types="bun" />
+
+import { expect, test } from "bun:test";
+import { settleAnalyticsProvider, trackEvent } from "./analytics";
+
+test("delivers once per healthy provider as scripts settle independently", () => {
+	const calls: string[] = [];
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		value: {},
+	});
+
+	trackEvent({ name: "message_sent", data: { model: "local" } });
+	window.umami = { track: (name) => calls.push(`umami:${name}`) };
+	settleAnalyticsProvider("umami", "ready");
+	expect(calls).toEqual(["umami:message_sent"]);
+
+	window.chili = { track: (name) => calls.push(`chili:${name}`) };
+	settleAnalyticsProvider("chili", "ready");
+	expect(calls).toEqual(["umami:message_sent", "chili:message_sent"]);
+
+	settleAnalyticsProvider("umami", "pending");
+	settleAnalyticsProvider("chili", "pending");
+	trackEvent({ name: "settings_opened" });
+	settleAnalyticsProvider("umami", "ready");
+	settleAnalyticsProvider("chili", "failed");
+	expect(calls).toEqual([
+		"umami:message_sent",
+		"chili:message_sent",
+		"umami:settings_opened",
+	]);
+
+	settleAnalyticsProvider("umami", "pending");
+	settleAnalyticsProvider("chili", "pending");
+	trackEvent({ name: "image_uploaded" });
+	settleAnalyticsProvider("umami", "failed");
+	settleAnalyticsProvider("chili", "failed");
+	expect(calls).not.toContain("umami:image_uploaded");
+	expect(calls).not.toContain("chili:image_uploaded");
+
+	delete (globalThis as { window?: Window }).window;
+});

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -40,3 +40,30 @@ test("delivers once per healthy provider as scripts settle independently", () =>
 
 	delete (globalThis as { window?: Window }).window;
 });
+
+test("isolates rejected provider results and continues fan-out", () => {
+	const calls: string[] = [];
+	let rejectionHandled = false;
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		value: {
+			umami: {
+				track: () => ({
+					catch(handler: () => unknown) {
+						rejectionHandled = true;
+						return handler();
+					},
+				}),
+			},
+			chili: { track: () => calls.push("chili") },
+		},
+	});
+
+	settleAnalyticsProvider("umami", "ready");
+	settleAnalyticsProvider("chili", "ready");
+	trackEvent({ name: "safe" });
+
+	expect(rejectionHandled).toBe(true);
+	expect(calls).toEqual(["chili"]);
+	delete (globalThis as { window?: Window }).window;
+});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,28 +1,102 @@
 interface AnalyticsEvent {
 	name: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	data?: Record<string, any>;
+	data?: Record<string, unknown>;
 }
 
-// Type declaration for umami window object
+type AnalyticsClient = {
+	track: (event: string, data?: Record<string, unknown>) => unknown;
+};
+
+type AnalyticsProvider = "umami" | "chili";
+type ProviderStatus = "pending" | "ready" | "failed";
+type PendingEvent = {
+	event: AnalyticsEvent;
+	deliveredProviders: Set<AnalyticsProvider>;
+	deliveredClients: Set<AnalyticsClient>;
+};
+
+const providerStatus: Record<AnalyticsProvider, ProviderStatus> = {
+	umami: "pending",
+	chili: "pending",
+};
+const pendingEvents: PendingEvent[] = [];
+const MAX_PENDING_EVENTS = 100;
+
 declare global {
 	interface Window {
-		umami?: {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			track: (event: string, data?: Record<string, any>) => void;
-		};
+		umami?: AnalyticsClient;
+		chili?: AnalyticsClient;
 	}
 }
 
-// Helper function to track events
-export const trackEvent = ({ name, data }: AnalyticsEvent) => {
-	try {
-		if (typeof window !== "undefined" && window.umami) {
-			window.umami.track(name, data);
+const analyticsClients = (): Record<
+	AnalyticsProvider,
+	AnalyticsClient | undefined
+> => ({
+	umami: window.umami,
+	chili: window.chili,
+});
+
+const deliver = (pending: PendingEvent) => {
+	const clients = analyticsClients();
+	let hasPendingProvider = false;
+	for (const provider of ["umami", "chili"] as const) {
+		if (
+			pending.deliveredProviders.has(provider) ||
+			providerStatus[provider] === "failed"
+		) {
+			continue;
 		}
-	} catch (error) {
-		console.error("Error tracking event:", error);
+		if (providerStatus[provider] === "pending") {
+			hasPendingProvider = true;
+			continue;
+		}
+		const client = clients[provider];
+		if (!client?.track) {
+			hasPendingProvider = true;
+			continue;
+		}
+		if (pending.deliveredClients.has(client)) {
+			pending.deliveredProviders.add(provider);
+			continue;
+		}
+		try {
+			void client.track(pending.event.name, pending.event.data);
+		} catch {
+			// Analytics must never interrupt the chat flow.
+		}
+		pending.deliveredClients.add(client);
+		pending.deliveredProviders.add(provider);
 	}
+	return !hasPendingProvider;
+};
+
+export const flushAnalyticsQueue = () => {
+	if (typeof window === "undefined") return;
+	while (pendingEvents.length > 0) {
+		if (!deliver(pendingEvents[0])) return;
+		pendingEvents.shift();
+	}
+};
+
+export const settleAnalyticsProvider = (
+	provider: AnalyticsProvider,
+	status: ProviderStatus,
+) => {
+	providerStatus[provider] = status;
+	flushAnalyticsQueue();
+};
+
+export const trackEvent = (event: AnalyticsEvent) => {
+	if (typeof window === "undefined") return;
+	const pending = {
+		event,
+		deliveredProviders: new Set<AnalyticsProvider>(),
+		deliveredClients: new Set<AnalyticsClient>(),
+	};
+	if (deliver(pending)) return;
+	if (pendingEvents.length === MAX_PENDING_EVENTS) pendingEvents.shift();
+	pendingEvents.push(pending);
 };
 
 // Message events
@@ -56,8 +130,7 @@ export const trackSettingsOpened = () => {
 	trackEvent({ name: "settings_opened" });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const trackSettingsChanged = (setting: string, value: any) => {
+export const trackSettingsChanged = (setting: string, value: unknown) => {
 	trackEvent({
 		name: "settings_changed",
 		data: {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -61,7 +61,15 @@ const deliver = (pending: PendingEvent) => {
 			continue;
 		}
 		try {
-			void client.track(pending.event.name, pending.event.data);
+			const result = client.track(pending.event.name, pending.event.data);
+			if (
+				result &&
+				typeof result === "object" &&
+				"catch" in result &&
+				typeof result.catch === "function"
+			) {
+				void result.catch(() => undefined);
+			}
 		} catch {
 			// Analytics must never interrupt the chat flow.
 		}


### PR DESCRIPTION
## Summary
- keep the existing Umami instrumentation active (and repair any invalid placeholder identity)
- place ChiliTrack alongside Umami using explicit side-by-side namespace isolation and exact production-domain gates
- fan out imperative events safely where present while keeping privacy, CSP, and runtime configuration accurate
- add or update regression coverage and CI where appropriate

## Rollout dependency
**DRAFT — DO NOT DEPLOY.**

Blocked on a14a-org/chilitrack#8 being merged and the resulting 0.2.4 script being deployed at `https://ingest.chilitrack.com/script.js`. The currently deployed script does not provide the required reliable `window.chili` side-by-side behavior. Umami remains authoritative during comparison. Existing advanced ChiliTrack modules remain unchanged; this rollout does not newly enable them.

## Verification
Repository-appropriate lint, type, unit, and production-build checks passed locally, and independent review is GO. Exact IDs and domain gates match the canonical 82-site rollout ledger in a14a-org/chilitrack#8.

No merge or deployment is part of this PR.